### PR TITLE
Add Styles Schema and remove Bootstrap Dependency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install
       - name: Publish to NPM
         run: npm publish
         env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "structor-reactformbuilder",
-  "version": "0.1.5",
+  "version": "0.9.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -17,12 +17,13 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "bootstrap": "^5.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.9.0"
   },
   "devDependencies": {
+    "@fullhuman/postcss-purgecss": "^5.0.0",
+    "@mojojoejo/vite-plugin-purgecss": "^1.1.0",
     "@storybook/addon-docs": "^7.4.6",
     "@storybook/addon-essentials": "7.4.2",
     "@storybook/addon-interactions": "7.4.2",
@@ -60,6 +61,6 @@
     "vitest": "^0.34.4"
   },
   "resolutions": {
-    "jackspeak": "2.1.1"
+    "jackspeak": "^2.1.1"
   }
 }

--- a/src/Demo.tsx
+++ b/src/Demo.tsx
@@ -22,6 +22,23 @@ export function Demo() {
     title: "Register",
     clearBtn: true,
     dev: true,
+    defaultStyles: {
+      title: "text-center mb-3",
+      form: "row",
+      buttons: {
+        wrapper: "text-center",
+        submit: "btn btn-primary mx-2 btn-sm",
+        clear: "btn btn-danger mx-2 btn-sm",
+      },
+      inputs: {
+        fieldWrapper: "mb-3 row",
+        inputWrapper: "col-sm-10",
+        input: "form-control",
+        label: "col-sm-2 col-form-label",
+        placeHolder: "",
+        helpText: "form-text",
+      },
+    },
     fields: [
       {
         fieldSchema: {
@@ -30,6 +47,14 @@ export function Demo() {
           label: "Username",
           placeHolder: "Enter your username",
           helpText: "Write Admin to see validation error",
+        },
+        stylesSchema: {
+          fieldWrapper: "mb-3 row",
+          inputWrapper: "col-sm-10",
+          input: "form-control",
+          label: "col-sm-2 col-form-label",
+          placeHolder: "",
+          helpText: "form-text",
         },
         validationSchema: {
           customValidators: [
@@ -98,6 +123,9 @@ export function Demo() {
             { label: "Prefer Not To Choose", value: "nothing" },
           ],
         },
+        stylesSchema: {
+          input: "form-select",
+        },
       },
       {
         fieldSchema: {
@@ -107,6 +135,12 @@ export function Demo() {
         },
         validationSchema: {
           isRequired: true,
+        },
+        stylesSchema: {
+          fieldWrapper: "mb-3 row",
+          inputWrapper: "form-check col-sm-10 offset-sm-2",
+          input: "form-check-input me-2 ",
+          label: "form-check-label",
         },
       },
     ],
@@ -165,7 +199,9 @@ export function Demo() {
     <>
       <div className="text-center">Structor React Form Builder</div>
       <br />
-      <Form schema={formSchema} values={user} setValues={setUser} handleFormSubmit={handleFormSubmit}></Form>
+      <div className="container text-light col-7">
+        <Form schema={formSchema} values={user} setValues={setUser} handleFormSubmit={handleFormSubmit}></Form>
+      </div>
       {/* <div className="row">
         {/* <div className="col-4" id="showCodeHere">
           <textarea id="showCodeHere" onChange={handleSChemaChange} value={JSON.stringify(formSchema)}></textarea>

--- a/src/Elements/Button/Button.tsx
+++ b/src/Elements/Button/Button.tsx
@@ -5,20 +5,12 @@ export interface IButtons {
   text?: string;
   type?: "button" | "submit" | "reset" | undefined;
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  cssClasses?: string;
-  htmlProps?: React.HTMLFactory<HTMLDivElement>;
+  className?: string;
+  // htmlProps?: React.HTMLProps<HTMLButtonElement>;
   children?: React.ReactNode;
 }
 
-const Buttons: React.FC<IButtons> = ({
-  id,
-  text,
-  type = "button",
-  cssClasses = "btn btn-primary mx-2 btn-sm",
-  onClick,
-  children,
-  htmlProps,
-}) => {
+const Buttons: React.FC<IButtons> = ({ id, text, type = "button", onClick, children, className }) => {
   if (!text) {
     switch (type) {
       case "submit":
@@ -34,7 +26,7 @@ const Buttons: React.FC<IButtons> = ({
 
   return (
     <>
-      <button type={type} id={id} className={cssClasses} onClick={onClick} {...htmlProps}>
+      <button type={type} id={id} onClick={onClick} className={className}>
         {text}
         {children}
       </button>

--- a/src/Elements/Inputs/CheckBoxInput/CheckBoxInput.tsx
+++ b/src/Elements/Inputs/CheckBoxInput/CheckBoxInput.tsx
@@ -7,43 +7,44 @@ import ValidFeedback from "@/Elements/UI/ValidFeedback/ValidFeedback";
 import { IField } from "@/Types/Field";
 
 export interface ICheckBoxInput extends IField {
-  label?: string;
-  helpText?: string;
-  isTouched?: boolean;
   handleChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
-  validationSchema?: IValidationSchema;
   children?: React.ReactNode;
 }
 
 function CheckBoxInput(props: ICheckBoxInput) {
   const { id, name, type, label, value, helpText, isTouched, handleChange, handleBlur, errors } = { ...props };
+  const { defaultStyles, stylesSchema } = { ...props };
 
   const isValid = isTouched && errors?.length === 0;
   const isInvalid = isTouched && errors && errors?.length > 0;
 
   const isRequired = props?.validationSchema?.isRequired ?? false;
 
-  return (
-    <div className="mb-3">
-      <div className="col-sm-10 offset-sm-2">
-        <div className="form-check">
-          <input
-            id={id || name}
-            name={name}
-            type="checkbox"
-            role={type}
-            className={`form-check-input ${isValid ? "is-valid" : ""} ${isInvalid ? "is-invalid" : ""}`}
-            onChange={handleChange}
-            onBlur={handleBlur}
-            value={value || ""}
-          />
-          <Label id={id || name} text={label} cssClasses="form-check-label" isRequired={isRequired} />
+  const fieldWrapper = stylesSchema?.fieldWrapper ?? defaultStyles?.inputs?.fieldWrapper;
+  const inputWrapper = stylesSchema?.inputWrapper ?? defaultStyles?.inputs?.inputWrapper;
+  const inputStyles = stylesSchema?.input ?? defaultStyles?.inputs?.input;
+  const labelStyles = stylesSchema?.label ?? defaultStyles?.inputs?.label;
+  const helpTextStyles = stylesSchema?.helpText ?? defaultStyles?.inputs?.helpText;
 
-          {helpText && <HelpText id={id || name} text={helpText} />}
-          {(!errors || errors.length === 0) && <ValidFeedback id={id || name} />}
-          {errors && errors.length > 0 && <InvalidFeedback id={id || name} errors={errors} />}
-        </div>
+  return (
+    <div className={fieldWrapper}>
+      <div className={inputWrapper}>
+        <input
+          id={id || name}
+          name={name}
+          type="checkbox"
+          role={type}
+          className={`${inputStyles} ${isValid ? "is-valid" : ""} ${isInvalid ? "is-invalid" : ""}`}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          value={value || ""}
+        />
+        <Label id={id || name} text={label} cssClasses={labelStyles} isRequired={isRequired} />
+
+        {helpText && <HelpText id={id || name} text={helpText} cssClasses={helpTextStyles} />}
+        {(!errors || errors.length === 0) && <ValidFeedback id={id || name} />}
+        {errors && errors.length > 0 && <InvalidFeedback id={id || name} errors={errors} />}
       </div>
     </div>
   );

--- a/src/Elements/Inputs/Dropdown/Dropdown.tsx
+++ b/src/Elements/Inputs/Dropdown/Dropdown.tsx
@@ -7,32 +7,34 @@ import ValidFeedback from "@/Elements/UI/ValidFeedback/ValidFeedback";
 import { IField } from "@/Types/Field";
 
 export interface IDropdown extends IField {
-  placeHolder?: string;
-  helpText?: string;
-  isTouched?: boolean;
   handleChange?: (event: React.ChangeEvent<HTMLSelectElement>) => void;
   handleBlur?: (event: React.FocusEvent<HTMLSelectElement>) => void;
   htmlProps?: React.SelectHTMLAttributes<HTMLSelectElement>;
-  children?: React.ReactNode;
 }
 
 function Dropdown(props: IDropdown) {
   const { id, name, placeHolder, label, value, options, helpText, isTouched, handleChange, handleBlur, errors } = {
     ...props,
   };
+  const { defaultStyles, stylesSchema } = { ...props };
 
   const isValid = isTouched && errors?.length === 0;
   const isInvalid = isTouched && errors && errors?.length > 0;
 
   const isRequired = props?.validationSchema?.isRequired ?? false;
 
+  const fieldWrapper = stylesSchema?.fieldWrapper ?? defaultStyles?.inputs?.fieldWrapper;
+  const inputWrapper = stylesSchema?.inputWrapper ?? defaultStyles?.inputs?.inputWrapper;
+  const inputStyles = stylesSchema?.input ?? defaultStyles?.inputs?.input;
+  const labelStyles = stylesSchema?.label ?? defaultStyles?.inputs?.label;
+  const helpTextStyles = stylesSchema?.helpText ?? defaultStyles?.inputs?.helpText;
+
   return (
-    <div className="mb-3 row">
-      {label && <Label id={id || name} text={label} isRequired={isRequired} cssClasses="col-sm-2" />}
-      <div className="col-sm-10">
+    <div className={fieldWrapper}>
+      {label && <Label id={id || name} text={label} isRequired={isRequired} cssClasses={labelStyles} />}
+      <div className={inputWrapper}>
         <select
-          className={`form-select ${isValid && "is-valid"} ${isInvalid && "is-invalid"}`}
-          aria-label="Default select"
+          className={`${inputStyles} ${isValid && "is-valid"} ${isInvalid && "is-invalid"}`}
           id={id || name}
           name={name}
           onChange={handleChange}
@@ -51,7 +53,7 @@ function Dropdown(props: IDropdown) {
           })}
         </select>
 
-        {helpText && <HelpText id={id || name} text={helpText} />}
+        {helpText && <HelpText id={id || name} text={helpText} cssClasses={helpTextStyles} />}
         {isValid && <ValidFeedback id={id || name} />}
         {isInvalid && <InvalidFeedback id={id || name} errors={errors} />}
       </div>

--- a/src/Elements/Inputs/TextInput/TextInput.tsx
+++ b/src/Elements/Inputs/TextInput/TextInput.tsx
@@ -9,14 +9,8 @@ import Label from "../../UI/Label/Label";
 import ValidFeedback from "../../UI/ValidFeedback/ValidFeedback";
 
 export interface ITextInput extends IField {
-  label?: string;
-  isTouched?: boolean;
   handleChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   handleBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
-  errors?: Array<IError>;
-  cssClasses?: string;
-  children?: React.ReactNode;
-  validationSchema?: IValidationSchema;
   htmlProps?: React.HTMLProps<HTMLInputElement>;
 }
 
@@ -32,7 +26,9 @@ function TextInput({
   handleChange,
   handleBlur,
   errors,
-  cssClasses = "form-control",
+  defaultStyles,
+  stylesSchema,
+  // cssClasses = "form-control",
   htmlProps,
   ...props
 }: ITextInput) {
@@ -41,13 +37,19 @@ function TextInput({
 
   const isRequired = props?.validationSchema?.isRequired ?? false;
 
+  const fieldWrapper = stylesSchema?.fieldWrapper ?? defaultStyles?.inputs?.fieldWrapper;
+  const inputWrapper = stylesSchema?.inputWrapper ?? defaultStyles?.inputs?.inputWrapper;
+  const inputStyles = stylesSchema?.input ?? defaultStyles?.inputs?.input;
+  const labelStyles = stylesSchema?.label ?? defaultStyles?.inputs?.label;
+  const helpTextStyles = stylesSchema?.helpText ?? defaultStyles?.inputs?.helpText;
+
   return (
-    <div className="mb-3 row">
-      {label && <Label id={id || name} cssClasses="col-sm-2 col-form-label" text={label} isRequired={isRequired} />}
-      <div className="col-sm-10">
+    <div className={fieldWrapper}>
+      {label && <Label id={id || name} cssClasses={labelStyles} text={label} isRequired={isRequired} />}
+      <div className={inputWrapper}>
         <input
           type={type}
-          className={`${cssClasses} ${isValid ? "is-valid" : ""} ${isInvalid ? "is-invalid" : ""}`}
+          className={`${inputStyles} ${isValid ? "is-valid" : ""} ${isInvalid ? "is-invalid" : ""}`}
           id={id || name}
           name={name}
           onChange={handleChange}
@@ -56,7 +58,7 @@ function TextInput({
           placeholder={placeHolder ?? label ?? name}
           {...htmlProps}
         />
-        {helpText && <HelpText id={id || name} text={helpText} />}
+        {helpText && <HelpText id={id || name} text={helpText} cssClasses={helpTextStyles} />}
         {(!errors || errors?.length === 0) && <ValidFeedback id={id || name} />}
         {errors && errors?.length > 0 && <InvalidFeedback id={id || name} errors={errors} />}
       </div>

--- a/src/FieldBuilder/FieldBuilder.tsx
+++ b/src/FieldBuilder/FieldBuilder.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import CheckBoxInput from "@/Elements/Inputs/CheckBoxInput/CheckBoxInput";
 import Dropdown from "@/Elements/Inputs/Dropdown/Dropdown";
+import { IFormStyles, IStylesSchema } from "@/Form/Form.types";
 
 import TextInput, { ITextInput } from "../Elements/Inputs/TextInput/TextInput";
 import { IError } from "../Types/Error";
@@ -10,6 +11,8 @@ import { IField, InputTypes } from "../Types/Field";
 export interface IFieldBuilder {
   fieldSchema: IField;
   validationSchema?: IValidationSchema;
+  defaultStyles?: IFormStyles;
+  stylesSchema?: IStylesSchema;
   value?: unknown;
   errors?: Array<IError>;
   handleInputBlur?:
@@ -70,7 +73,6 @@ export default function FieldBuilder(field: IFieldBuilder) {
           {...field}
           {...fieldSchema}
           {...htmlFields}
-          label={fieldSchema.label}
           value={value}
           isTouched={isTouched}
           handleBlur={handleBlur}
@@ -83,7 +85,6 @@ export default function FieldBuilder(field: IFieldBuilder) {
           {...field}
           {...fieldSchema}
           {...htmlFields}
-          label={fieldSchema.label}
           value={value}
           isTouched={isTouched}
           handleBlur={handleBlur}

--- a/src/FieldsBuilder/FieldsBuilder.tsx
+++ b/src/FieldsBuilder/FieldsBuilder.tsx
@@ -1,3 +1,5 @@
+import { IFormStyles } from "@/Form/Form.types";
+
 import FieldBuilder, { IFieldBuilder } from "../FieldBuilder/FieldBuilder";
 import { IError } from "../Types/Error";
 
@@ -5,6 +7,7 @@ export interface IFieldsBuilder {
   fields: Array<IFieldBuilder>;
   values?: any;
   setValues?: any;
+  defaultStyles?: IFormStyles;
   isFormCleared?: boolean;
   isFormSubmit?: boolean;
   handleInputChange?: any;
@@ -24,6 +27,7 @@ export default function FieldsBuilder(props: IFieldsBuilder) {
         {...field}
         key={field.fieldSchema.type + index}
         value={values ? values[field.fieldSchema.name] : ""}
+        defaultStyles={props.defaultStyles}
         // setValues={setValues}
         handleInputChange={handleInputChange}
         handleInputBlur={handleInputBlur}

--- a/src/Form/Form.mdx
+++ b/src/Form/Form.mdx
@@ -28,8 +28,35 @@ IFormSchema {
   fields: Array<IFieldBuilder>; // Array of fields
   dev?: boolean;                // Show dev tools
   clearBtn?: boolean;           // Show clear button
+  defaultStyles?: IFormStyles; // Default styles for the form and inputs
 }
 ```
+
+Styles will have the following structure: (You should provide the css classes as a string)
+
+````tsx
+IFormStyles {
+  title?: string;           // Title of the form
+  form?: string;            // Form wrapper
+  buttons?: {               // Buttons
+    wrapper?: string;       // Wrapper
+    submit?: string;        // Submit button
+    clear?: string;         // Clear button
+  };
+  inputs?: IStylesSchema;
+}```
+
+The input styles will have the following structure: (Default styles are used if no styles are provided)
+```tsx
+IStylesSchema {
+  fieldWrapper?: string;
+  inputWrapper?: string;
+  input?: string;
+  label?: string;
+  placeHolder?: string;
+  helpText?: string;
+}
+````
 
 The fields should have the following structure:
 
@@ -37,6 +64,7 @@ The fields should have the following structure:
 IFieldBuilder {
   fieldSchema: IField;
   validationSchema?: IValidationSchema;
+  IStylesSchema?: IStylesSchema;
 }
 ```
 
@@ -59,6 +87,14 @@ Example of a FieldBuilder:
           },
         ],
         isRequired: true,
+      },
+      stylesSchema: {
+        fieldWrapper: "mb-3 row",
+        inputWrapper: "col-sm-10",
+        input: "form-control",
+        label: "col-sm-2 col-form-label",
+        placeHolder: "",
+        helpText: "form-text",
       }
 ```
 
@@ -144,6 +180,23 @@ let formSchema: IFormSchema = {
   title: "Register",
   clearBtn: true,
   dev: true,
+  defaultStyles: {
+    title: "text-center mb-3",
+    form: "row",
+    buttons: {
+      wrapper: "text-center",
+      submit: "btn btn-primary mx-2 btn-sm",
+      clear: "btn btn-danger mx-2 btn-sm",
+    },
+    inputs: {
+      fieldWrapper: "mb-3 row",
+      inputWrapper: "col-sm-10",
+      input: "form-control",
+      label: "col-sm-2 col-form-label",
+      placeHolder: "",
+      helpText: "form-text",
+    },
+  },
   fields: [
     {
       fieldSchema: {
@@ -152,6 +205,14 @@ let formSchema: IFormSchema = {
         label: "Username",
         placeHolder: "Enter your username",
         helpText: "Write Admin to see validation error",
+      },
+      stylesSchema: {
+        fieldWrapper: "mb-3 row",
+        inputWrapper: "col-sm-10",
+        input: "form-control",
+        label: "col-sm-2 col-form-label",
+        placeHolder: "",
+        helpText: "form-text",
       },
       validationSchema: {
         customValidators: [
@@ -220,6 +281,9 @@ let formSchema: IFormSchema = {
           { label: "Prefer Not To Choose", value: "nothing" },
         ],
       },
+      stylesSchema: {
+        input: "form-select",
+      },
     },
     {
       fieldSchema: {
@@ -229,6 +293,12 @@ let formSchema: IFormSchema = {
       },
       validationSchema: {
         isRequired: true,
+      },
+      stylesSchema: {
+        fieldWrapper: "mb-3 row",
+        inputWrapper: "form-check col-sm-10 offset-sm-2",
+        input: "form-check-input me-2 ",
+        label: "form-check-label",
       },
     },
   ],

--- a/src/Form/Form.mocks.ts
+++ b/src/Form/Form.mocks.ts
@@ -25,6 +25,23 @@ const formSchema: IFormSchema = {
   title: "Register",
   clearBtn: true,
   dev: true,
+  defaultStyles: {
+    title: "text-center mb-3",
+    form: "row",
+    buttons: {
+      wrapper: "text-center",
+      submit: "btn btn-primary mx-2 btn-sm",
+      clear: "btn btn-danger mx-2 btn-sm",
+    },
+    inputs: {
+      fieldWrapper: "mb-3 row",
+      inputWrapper: "col-sm-10",
+      input: "form-control",
+      label: "col-sm-2 col-form-label",
+      placeHolder: "",
+      helpText: "form-text",
+    },
+  },
   fields: [
     {
       fieldSchema: {
@@ -33,6 +50,14 @@ const formSchema: IFormSchema = {
         label: "Username",
         placeHolder: "Enter your username",
         helpText: "Write Admin to see validation error",
+      },
+      stylesSchema: {
+        fieldWrapper: "mb-3 row",
+        inputWrapper: "col-sm-10",
+        input: "form-control",
+        label: "col-sm-2 col-form-label",
+        placeHolder: "",
+        helpText: "form-text",
       },
       validationSchema: {
         customValidators: [
@@ -101,6 +126,9 @@ const formSchema: IFormSchema = {
           { label: "Prefer Not To Choose", value: "nothing" },
         ],
       },
+      stylesSchema: {
+        input: "form-select",
+      },
     },
     {
       fieldSchema: {
@@ -110,6 +138,12 @@ const formSchema: IFormSchema = {
       },
       validationSchema: {
         isRequired: true,
+      },
+      stylesSchema: {
+        fieldWrapper: "mb-3 row",
+        inputWrapper: "form-check col-sm-10 offset-sm-2",
+        input: "form-check-input me-2 ",
+        label: "form-check-label",
       },
     },
   ],

--- a/src/Form/Form.tsx
+++ b/src/Form/Form.tsx
@@ -12,7 +12,7 @@ import { FormActionsTypes, IForm, IFormAction, IFormState } from "./Form.types";
 export default function Form({
   values,
   setValues,
-  schema: { title, fields, clearBtn, dev = false },
+  schema: { title, fields, defaultStyles, clearBtn, dev = false },
   handleFormSubmit,
   children,
 }: IForm) {
@@ -148,7 +148,7 @@ export default function Form({
   };
 
   return (
-    <div className="container text-light col-7">
+    <>
       {dev && (
         <DevInfo
           isTouched={formState.isTouched}
@@ -158,25 +158,26 @@ export default function Form({
         />
       )}
 
-      <h1 className="text-center mb-3">{title}</h1>
-      <form onSubmit={handleSubmit} noValidate className="row">
+      <h1 className={defaultStyles?.title}>{title}</h1>
+      <form onSubmit={handleSubmit} noValidate className={defaultStyles?.form}>
         <FieldsBuilder
           fields={fields}
           isFormSubmit={formState.isSubmitted}
           isFormCleared={formState.isCleared}
           setValues={setFormValues}
           values={formValues}
+          defaultStyles={defaultStyles}
           handleInputChange={handleInputChange}
           handleInputBlur={handleInputBlur}
           errors={formState.errors}
         />
         {children}
 
-        <div className="text-center">
-          <Button type="submit" />
-          {clearBtn && <Button type="reset" onClick={handleClear} />}
+        <div className={defaultStyles?.buttons?.wrapper}>
+          <Button type="submit" className={defaultStyles?.buttons?.submit} />
+          {clearBtn && <Button type="reset" onClick={handleClear} className={defaultStyles?.buttons?.clear} />}
         </div>
       </form>
-    </div>
+    </>
   );
 }

--- a/src/Form/Form.types.tsx
+++ b/src/Form/Form.types.tsx
@@ -12,6 +12,7 @@ export interface IForm {
 
 export interface IFormSchema {
   title?: string;
+  defaultStyles?: IFormStyles;
   fields: Array<IFieldBuilder>;
   errors?: Array<IError>;
   dev?: boolean;
@@ -36,4 +37,24 @@ export enum FormActionsTypes {
   CLEAR = "CLEAR",
   UPDATE = "UPDATE",
   UPDATE_ERRORS = "UPDATE_ERRORS",
+}
+
+export interface IFormStyles {
+  title?: string;
+  form?: string;
+  buttons?: {
+    wrapper?: string;
+    submit?: string;
+    clear?: string;
+  };
+  inputs?: IStylesSchema;
+}
+
+export interface IStylesSchema {
+  fieldWrapper?: string;
+  inputWrapper?: string;
+  input?: string;
+  label?: string;
+  placeHolder?: string;
+  helpText?: string;
 }

--- a/src/Types/Field.ts
+++ b/src/Types/Field.ts
@@ -1,3 +1,5 @@
+import { IFormStyles, IStylesSchema } from "@/Form/Form.types";
+
 import { IError } from "./Error";
 
 export interface IField {
@@ -10,7 +12,10 @@ export interface IField {
   label?: string;
   options?: Array<IOption>;
   errors?: Array<IError>;
+  isTouched?: boolean;
   validationSchema?: IValidationSchema;
+  defaultStyles?: IFormStyles;
+  stylesSchema?: IStylesSchema;
   parentName?: string;
   children?: React.ReactNode;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,42 +1,45 @@
-$primary: teal;
+// $primary: teal;
 // $secondary: #ff6347;
-$form-text-color: #4c4c4c;
-:root{--bs-secondary-color: #4c4c4c}
-@import "/node_modules/bootstrap/scss/bootstrap.scss";
+// $form-text-color: #4c4c4c;
+// :root{--bs-secondary-color: #4c4c4c}
+// @import "/node_modules/bootstrap/scss/bootstrap.scss";
 
-:root {
-  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 400;
 
-  margin: 0 auto;
-  // text-align: center;
+// :root {
+//   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+//   font-size: 16px;
+//   line-height: 24px;
+//   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #1d2022; //$dark; //#242424 //#212529 //#1d2022
+//   margin: 0 auto;
+//   // text-align: center;
 
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-text-size-adjust: 100%;
-}
+//   color-scheme: light dark;
+//   color: rgba(255, 255, 255, 0.87);
+//   background-color: #1d2022; //$dark; //#242424 //#212529 //#1d2022
 
-body {
-  margin: 0;
-  //display: flex;
-  //place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-  background-color: #1d2022;
-  color: $light;
-}
+//   font-synthesis: none;
+//   text-rendering: optimizeLegibility;
+//   -webkit-font-smoothing: antialiased;
+//   -moz-osx-font-smoothing: grayscale;
+//   -webkit-text-size-adjust: 100%;
+// }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-}
+// body {
+//   margin: 0;
+//   //display: flex;
+//   //place-items: center;
+//   min-width: 320px;
+//   min-height: 100vh;
+//   background-color: #1d2022;
+//   color: $light;
+// }
+
+// @media (prefers-color-scheme: light) {
+//   :root {
+//     color: #213547;
+//     background-color: #ffffff;
+//   }
+// }
+
+@import "./main.scss";

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,0 +1,975 @@
+@charset "UTF-8";
+.string {
+  color: green;
+}
+.number {
+  color: #ff8c00;
+}
+.boolean {
+  color: #00f;
+}
+.null {
+  color: #f0f;
+}
+.key {
+  color: red;
+}
+:root {
+  --bs-secondary-color: #4c4c4c;
+} /*!
+ * Bootstrap  v5.3.2 (https://getbootstrap.com/)
+ * Copyright 2011-2023 The Bootstrap Authors
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ */
+:root {
+  --bs-blue: #0d6efd
+  --bs-indigo: #6610f2;
+  --bs-purple: #6f42c1;
+  --bs-pink: #d63384;
+  --bs-red: #dc3545;
+  --bs-orange: #fd7e14;
+  --bs-yellow: #ffc107;
+  --bs-green: #198754;
+  --bs-teal: #20c997;
+  --bs-cyan: #0dcaf0;
+  --bs-black: #000;
+  --bs-white: #fff;
+  --bs-gray: #6c757d;
+  --bs-gray-dark: #343a40;
+  --bs-gray-100: #f8f9fa;
+  --bs-gray-200: #e9ecef;
+  --bs-gray-300: #dee2e6;
+  --bs-gray-400: #ced4da;
+  --bs-gray-500: #adb5bd;
+  --bs-gray-600: #6c757d;
+  --bs-gray-700: #495057;
+  --bs-gray-800: #343a40;
+  --bs-gray-900: #212529;
+  --bs-primary: teal;
+  --bs-secondary: #6c757d;
+  --bs-success: #198754;
+  --bs-info: #0dcaf0;
+  --bs-warning: #ffc107;
+  --bs-danger: #dc3545;
+  --bs-light: #f8f9fa;
+  --bs-dark: #212529;
+  --bs-primary-rgb: 0, 128, 128;
+  --bs-secondary-rgb: 108, 117, 125;
+  --bs-success-rgb: 25, 135, 84;
+  --bs-info-rgb: 13, 202, 240;
+  --bs-warning-rgb: 255, 193, 7;
+  --bs-danger-rgb: 220, 53, 69;
+  --bs-light-rgb: 248, 249, 250;
+  --bs-dark-rgb: 33, 37, 41;
+  --bs-primary-text-emphasis: #003333;
+  --bs-secondary-text-emphasis: #2b2f32;
+  --bs-success-text-emphasis: #0a3622;
+  --bs-info-text-emphasis: #055160;
+  --bs-warning-text-emphasis: #664d03;
+  --bs-danger-text-emphasis: #58151c;
+  --bs-light-text-emphasis: #495057;
+  --bs-dark-text-emphasis: #495057;
+  --bs-primary-bg-subtle: #cce6e6;
+  --bs-secondary-bg-subtle: #e2e3e5;
+  --bs-success-bg-subtle: #d1e7dd;
+  --bs-info-bg-subtle: #cff4fc;
+  --bs-warning-bg-subtle: #fff3cd;
+  --bs-danger-bg-subtle: #f8d7da;
+  --bs-light-bg-subtle: #fcfcfd;
+  --bs-dark-bg-subtle: #ced4da;
+  --bs-primary-border-subtle: #99cccc;
+  --bs-secondary-border-subtle: #c4c8cb;
+  --bs-success-border-subtle: #a3cfbb;
+  --bs-info-border-subtle: #9eeaf9;
+  --bs-warning-border-subtle: #ffe69c;
+  --bs-danger-border-subtle: #f1aeb5;
+  --bs-light-border-subtle: #e9ecef;
+  --bs-dark-border-subtle: #adb5bd;
+  --bs-white-rgb: 255, 255, 255;
+  --bs-black-rgb: 0, 0, 0;
+  --bs-font-sans-serif: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans",
+    Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+  --bs-font-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --bs-gradient: linear-gradient(180deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0));
+  --bs-body-font-family: var(--bs-font-sans-serif);
+  --bs-body-font-size: 1rem;
+  --bs-body-font-weight: 400;
+  --bs-body-line-height: 1.5;
+  --bs-body-color: #212529;
+  --bs-body-color-rgb: 33, 37, 41;
+  --bs-body-bg: #fff;
+  --bs-body-bg-rgb: 255, 255, 255;
+  --bs-emphasis-color: #000;
+  --bs-emphasis-color-rgb: 0, 0, 0;
+  --bs-secondary-color: rgba(33, 37, 41, 0.75);
+  --bs-secondary-color-rgb: 33, 37, 41;
+  --bs-secondary-bg: #e9ecef;
+  --bs-secondary-bg-rgb: 233, 236, 239;
+  --bs-tertiary-color: rgba(33, 37, 41, 0.5);
+  --bs-tertiary-color-rgb: 33, 37, 41;
+  --bs-tertiary-bg: #f8f9fa;
+  --bs-tertiary-bg-rgb: 248, 249, 250;
+  --bs-heading-color: inherit;
+  --bs-link-color: teal;
+  --bs-link-color-rgb: 0, 128, 128;
+  --bs-link-decoration: underline;
+  --bs-link-hover-color: #006666;
+  --bs-link-hover-color-rgb: 0, 102, 102;
+  --bs-code-color: #d63384;
+  --bs-highlight-color: #212529;
+  --bs-highlight-bg: #fff3cd;
+  --bs-border-width: 1px;
+  --bs-border-style: solid;
+  --bs-border-color: #dee2e6;
+  --bs-border-color-translucent: rgba(0, 0, 0, 0.175);
+  --bs-border-radius: 0.375rem;
+  --bs-border-radius-sm: 0.25rem;
+  --bs-border-radius-lg: 0.5rem;
+  --bs-border-radius-xl: 1rem;
+  --bs-border-radius-xxl: 2rem;
+  --bs-border-radius-2xl: var(--bs-border-radius-xxl);
+  --bs-border-radius-pill: 50rem;
+  --bs-box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+  --bs-box-shadow-sm: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+  --bs-box-shadow-lg: 0 1rem 3rem rgba(0, 0, 0, 0.175);
+  --bs-box-shadow-inset: inset 0 1px 2px rgba(0, 0, 0, 0.075);
+  --bs-focus-ring-width: 0.25rem;
+  --bs-focus-ring-opacity: 0.25;
+  --bs-focus-ring-color: rgba(0, 128, 128, 0.25);
+  --bs-form-valid-color: #198754;
+  --bs-form-valid-border-color: #198754;
+  --bs-form-invalid-color: #dc3545;
+  --bs-form-invalid-border-color: #dc3545;
+}
+*,
+*:before,
+*:after {
+  box-sizing: border-box ;
+}
+@media (prefers-reduced-motion: no-preference) {
+  :root {
+    scroll-behavior: smooth;
+  }
+}
+body {
+  margin: 0;
+  font-family: var(--bs-body-font-family);
+  font-size: var(--bs-body-font-size);
+  font-weight: var(--bs-body-font-weight);
+  line-height: var(--bs-body-line-height);
+  color: var(--bs-body-color);
+  text-align: var(--bs-body-text-align);
+  background-color: var(--bs-body-bg);
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+hr {
+  margin: 1rem 0;
+  color: inherit;
+  border: 0;
+  border-top: var(--bs-border-width) solid;
+  opacity: 0.25;
+}
+h1,
+.h1 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+  line-height: 1.2;
+  color: var(--bs-heading-color);
+}
+h1,
+.h1 {
+  font-size: calc(1.375rem + 1.5vw);
+}
+@media (min-width: 1200px) {
+  h1,
+  .h1 {
+    font-size: 2.5rem;
+  }
+}
+p {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+ol,
+ul {
+  padding-left: 2rem;
+}
+ol,
+ul,
+dl {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+ol ol,
+ul ul,
+ol ul,
+ul ol {
+  margin-bottom: 0;
+}
+dt {
+  font-weight: 700;
+}
+dd {
+  margin-bottom: 0.5rem;
+  margin-left: 0;
+}
+b {
+  font-weight: bolder;
+}
+a {
+  color: rgba(var(--bs-link-color-rgb), var(--bs-link-opacity, 1));
+  text-decoration: underline;
+}
+a:hover {
+  --bs-link-color-rgb: var(--bs-link-hover-color-rgb);
+}
+a:not([href]):not([class]),
+a:not([href]):not([class]):hover {
+  color: inherit;
+  text-decoration: none;
+}
+code {
+  font-family: var(--bs-font-monospace);
+  font-size: 1em;
+}
+code {
+  font-size: 0.875em;
+  color: var(--bs-code-color);
+  word-wrap: break-word;
+}
+a > code {
+  color: inherit;
+}
+img,
+svg {
+  vertical-align: middle;
+}
+tr,
+td {
+  border-color: inherit;
+  border-style: solid;
+  border-width: 0;
+}
+label {
+  display: inline-block;
+}
+button {
+  border-radius: 0;
+}
+button:focus:not(:focus-visible) {
+  outline: 0;
+}
+input,
+button,
+select,
+textarea {
+  margin: 0;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+button,
+select {
+  text-transform: none;
+}
+[role="button"] {
+  cursor: pointer;
+}
+select {
+  word-wrap: normal;
+}
+select:disabled {
+  opacity: 1;
+}
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  -webkit-appearance: button;
+}
+button:not(:disabled),
+[type="button"]:not(:disabled),
+[type="reset"]:not(:disabled),
+[type="submit"]:not(:disabled) {
+  cursor: pointer;
+}
+::-moz-focus-inner {
+  padding: 0;
+  border-style: none;
+}
+textarea {
+  resize: vertical;
+}
+::-webkit-datetime-edit-fields-wrapper,
+::-webkit-datetime-edit-text,
+::-webkit-datetime-edit-minute,
+::-webkit-datetime-edit-hour-field,
+::-webkit-datetime-edit-day-field,
+::-webkit-datetime-edit-month-field,
+::-webkit-datetime-edit-year-field {
+  padding: 0;
+}
+::-webkit-inner-spin-button {
+  height: auto;
+}
+[type="search"] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+::file-selector-button {
+  font: inherit;
+  -webkit-appearance: button;
+}
+iframe {
+  border: 0;
+}
+progress {
+  vertical-align: baseline;
+}
+[hidden] {
+  display: none !important;
+}
+.container {
+  --bs-gutter-x: 1.5rem;
+  --bs-gutter-y: 0;
+  width: 100%;
+  padding-right: calc(var(--bs-gutter-x) * 0.5);
+  padding-left: calc(var(--bs-gutter-x) * 0.5);
+  margin-right: auto;
+  margin-left: auto;
+}
+@media (min-width: 576px) {
+  .container {
+    max-width: 540px;
+  }
+}
+@media (min-width: 768px) {
+  .container {
+    max-width: 720px;
+  }
+}
+@media (min-width: 992px) {
+  .container {
+    max-width: 960px;
+  }
+}
+@media (min-width: 1200px) {
+  .container {
+    max-width: 1140px;
+  }
+}
+@media (min-width: 1400px) {
+  .container {
+    max-width: 1320px;
+  }
+}
+:root {
+  --bs-breakpoint-xs: 0;
+  --bs-breakpoint-sm: 576px;
+  --bs-breakpoint-md: 768px;
+  --bs-breakpoint-lg: 992px;
+  --bs-breakpoint-xl: 1200px;
+  --bs-breakpoint-xxl: 1400px;
+}
+.row {
+  --bs-gutter-x: 1.5rem;
+  --bs-gutter-y: 0;
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: calc(-1 * var(--bs-gutter-y));
+  margin-right: calc(-0.5 * var(--bs-gutter-x));
+  margin-left: calc(-0.5 * var(--bs-gutter-x));
+}
+.row > * {
+  flex-shrink: 0;
+  width: 100%;
+  max-width: 100%;
+  padding-right: calc(var(--bs-gutter-x) * 0.5);
+  padding-left: calc(var(--bs-gutter-x) * 0.5);
+  margin-top: var(--bs-gutter-y);
+}
+.col {
+  flex: 1 0 0%;
+}
+.col-7 {
+  flex: 0 0 auto;
+  width: 58.33333333%;
+}
+@media (min-width: 576px) {
+  .col-sm-2 {
+    flex: 0 0 auto;
+    width: 16.66666667%;
+  }
+  .col-sm-10 {
+    flex: 0 0 auto;
+    width: 83.33333333%;
+  }
+  .offset-sm-2 {
+    margin-left: 16.66666667%;
+  }
+}
+.form-label {
+  margin-bottom: 0.5rem;
+}
+.col-form-label {
+  padding-top: calc(0.375rem + var(--bs-border-width));
+  padding-bottom: calc(0.375rem + var(--bs-border-width));
+  margin-bottom: 0;
+  font-size: inherit;
+  line-height: 1.5;
+}
+.form-text {
+  margin-top: 0.25rem;
+  font-size: 0.875em;
+  color: #4c4c4c;
+}
+.form-control {
+  display: block;
+  width: 100%;
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--bs-body-color);
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: var(--bs-body-bg);
+  background-clip: padding-box;
+  border: var(--bs-border-width) solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+  transition:
+    border-color 0.15s ease-in-out,
+    box-shadow 0.15s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .form-control {
+    transition: none;
+  }
+}
+.form-control[type="file"] {
+  overflow: hidden;
+}
+.form-control[type="file"]:not(:disabled):not([readonly]) {
+  cursor: pointer;
+}
+.form-control:focus {
+  color: var(--bs-body-color);
+  background-color: var(--bs-body-bg);
+  border-color: #80c0c0;
+  outline: 0;
+  box-shadow: 0 0 0 0.25rem #00808040;
+}
+.form-control::-webkit-date-and-time-value {
+  min-width: 85px;
+  height: 1.5em;
+  margin: 0;
+}
+.form-control::-webkit-datetime-edit {
+  display: block;
+  padding: 0;
+}
+.form-control::placeholder {
+  color: var(--bs-secondary-color);
+  opacity: 1;
+}
+.form-control:disabled {
+  background-color: var(--bs-secondary-bg);
+  opacity: 1;
+}
+.form-control::file-selector-button {
+  padding: 0.375rem 0.75rem;
+  margin: -0.375rem -0.75rem;
+  margin-inline-end: 0.75rem;
+  color: var(--bs-body-color);
+  background-color: var(--bs-tertiary-bg);
+  pointer-events: none;
+  border-color: inherit;
+  border-style: solid;
+  border-width: 0;
+  border-inline-end-width: var(--bs-border-width);
+  border-radius: 0;
+  transition:
+    color 0.15s ease-in-out,
+    background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out,
+    box-shadow 0.15s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .form-control::file-selector-button {
+    transition: none;
+  }
+}
+.form-control:hover:not(:disabled):not([readonly])::file-selector-button {
+  background-color: var(--bs-secondary-bg);
+}
+textarea.form-control {
+  min-height: calc(1.5em + 0.75rem + calc(var(--bs-border-width) * 2));
+}
+.form-select {
+  --bs-form-select-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
+  display: block;
+  width: 100%;
+  padding: 0.375rem 2.25rem 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--bs-body-color);
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: var(--bs-body-bg);
+  background-image: var(--bs-form-select-bg-img), var(--bs-form-select-bg-icon, none);
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 16px 12px;
+  border: var(--bs-border-width) solid var(--bs-border-color);
+  border-radius: var(--bs-border-radius);
+  transition:
+    border-color 0.15s ease-in-out,
+    box-shadow 0.15s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .form-select {
+    transition: none;
+  }
+}
+.form-select:focus {
+  border-color: #80c0c0;
+  outline: 0;
+  box-shadow: 0 0 0 0.25rem #00808040;
+}
+.form-select[multiple],
+.form-select[size]:not([size="1"]) {
+  padding-right: 0.75rem;
+  background-image: none;
+}
+.form-select:disabled {
+  background-color: var(--bs-secondary-bg);
+}
+.form-select:-moz-focusring {
+  color: transparent;
+  text-shadow: 0 0 0 var(--bs-body-color);
+}
+.form-check {
+  display: block;
+  min-height: 1.5rem;
+  padding-left: 1.5em;
+  margin-bottom: 0.125rem;
+}
+.form-check .form-check-input {
+  float: left;
+  margin-left: -1.5em;
+}
+.form-check-input {
+  --bs-form-check-bg: var(--bs-body-bg);
+  flex-shrink: 0;
+  width: 1em;
+  height: 1em;
+  margin-top: 0.25em;
+  vertical-align: top;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-color: var(--bs-form-check-bg);
+  background-image: var(--bs-form-check-bg-image);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  border: var(--bs-border-width) solid var(--bs-border-color);
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+}
+.form-check-input[type="checkbox"] {
+  border-radius: 0.25em;
+}
+.form-check-input[type="radio"] {
+  border-radius: 50%;
+}
+.form-check-input:active {
+  filter: brightness(90%);
+}
+.form-check-input:focus {
+  border-color: #80c0c0;
+  outline: 0;
+  box-shadow: 0 0 0 0.25rem #00808040;
+}
+.form-check-input:checked {
+  background-color: teal;
+  border-color: teal;
+}
+.form-check-input:checked[type="checkbox"] {
+  --bs-form-check-bg-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/%3e%3c/svg%3e");
+}
+.form-check-input:checked[type="radio"] {
+  --bs-form-check-bg-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='2' fill='%23fff'/%3e%3c/svg%3e");
+}
+.form-check-input[type="checkbox"]:indeterminate {
+  background-color: teal;
+  border-color: teal;
+  --bs-form-check-bg-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='M6 10h8'/%3e%3c/svg%3e");
+}
+.form-check-input:disabled {
+  pointer-events: none;
+  filter: none;
+  opacity: 0.5;
+}
+.form-check-input[disabled] ~ .form-check-label,
+.form-check-input:disabled ~ .form-check-label {
+  cursor: default;
+  opacity: 0.5;
+}
+.valid-feedback {
+  display: none;
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 0.875em;
+  color: var(--bs-form-valid-color);
+}
+.is-valid ~ .valid-feedback {
+  display: block;
+}
+.form-control.is-valid {
+  border-color: var(--bs-form-valid-border-color);
+  padding-right: calc(1.5em + 0.75rem);
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%23198754' d='M2.3 6.73.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right calc(0.375em + 0.1875rem) center;
+  background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+}
+.form-control.is-valid:focus {
+  border-color: var(--bs-form-valid-border-color);
+  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
+}
+textarea.form-control.is-valid {
+  padding-right: calc(1.5em + 0.75rem);
+  background-position: top calc(0.375em + 0.1875rem) right calc(0.375em + 0.1875rem);
+}
+.form-select.is-valid {
+  border-color: var(--bs-form-valid-border-color);
+}
+.form-select.is-valid:not([multiple]):not([size]),
+.form-select.is-valid:not([multiple])[size="1"] {
+  --bs-form-select-bg-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%23198754' d='M2.3 6.73.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
+  padding-right: 4.125rem;
+  background-position:
+    right 0.75rem center,
+    center right 2.25rem;
+  background-size:
+    16px 12px,
+    calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+}
+.form-select.is-valid:focus {
+  border-color: var(--bs-form-valid-border-color);
+  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
+}
+.form-check-input.is-valid {
+  border-color: var(--bs-form-valid-border-color);
+}
+.form-check-input.is-valid:checked {
+  background-color: var(--bs-form-valid-color);
+}
+.form-check-input.is-valid:focus {
+  box-shadow: 0 0 0 0.25rem rgba(var(--bs-success-rgb), 0.25);
+}
+.form-check-input.is-valid ~ .form-check-label {
+  color: var(--bs-form-valid-color);
+}
+.invalid-feedback {
+  display: none;
+  width: 100%;
+  margin-top: 0.25rem;
+  font-size: 0.875em;
+  color: var(--bs-form-invalid-color);
+}
+.is-invalid ~ .invalid-feedback {
+  display: block;
+}
+.form-control.is-invalid {
+  border-color: var(--bs-form-invalid-border-color);
+  padding-right: calc(1.5em + 0.75rem);
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23dc3545'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right calc(0.375em + 0.1875rem) center;
+  background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+}
+.form-control.is-invalid:focus {
+  border-color: var(--bs-form-invalid-border-color);
+  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
+}
+textarea.form-control.is-invalid {
+  padding-right: calc(1.5em + 0.75rem);
+  background-position: top calc(0.375em + 0.1875rem) right calc(0.375em + 0.1875rem);
+}
+.form-select.is-invalid {
+  border-color: var(--bs-form-invalid-border-color);
+}
+.form-select.is-invalid:not([multiple]):not([size]),
+.form-select.is-invalid:not([multiple])[size="1"] {
+  --bs-form-select-bg-icon: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23dc3545'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e");
+  padding-right: 4.125rem;
+  background-position:
+    right 0.75rem center,
+    center right 2.25rem;
+  background-size:
+    16px 12px,
+    calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+}
+.form-select.is-invalid:focus {
+  border-color: var(--bs-form-invalid-border-color);
+  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
+}
+.form-check-input.is-invalid {
+  border-color: var(--bs-form-invalid-border-color);
+}
+.form-check-input.is-invalid:checked {
+  background-color: var(--bs-form-invalid-color);
+}
+.form-check-input.is-invalid:focus {
+  box-shadow: 0 0 0 0.25rem rgba(var(--bs-danger-rgb), 0.25);
+}
+.form-check-input.is-invalid ~ .form-check-label {
+  color: var(--bs-form-invalid-color);
+}
+.btn {
+  --bs-btn-padding-x: 0.75rem;
+  --bs-btn-padding-y: 0.375rem;
+  --bs-btn-font-family: ;
+  --bs-btn-font-size: 1rem;
+  --bs-btn-font-weight: 400;
+  --bs-btn-line-height: 1.5;
+  --bs-btn-color: var(--bs-body-color);
+  --bs-btn-bg: transparent;
+  --bs-btn-border-width: var(--bs-border-width);
+  --bs-btn-border-color: transparent;
+  --bs-btn-border-radius: var(--bs-border-radius);
+  --bs-btn-hover-border-color: transparent;
+  --bs-btn-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), 0 1px 1px rgba(0, 0, 0, 0.075);
+  --bs-btn-disabled-opacity: 0.65;
+  --bs-btn-focus-box-shadow: 0 0 0 0.25rem rgba(var(--bs-btn-focus-shadow-rgb), 0.5);
+  display: inline-block;
+  padding: var(--bs-btn-padding-y) var(--bs-btn-padding-x);
+  font-family: var(--bs-btn-font-family);
+  font-size: var(--bs-btn-font-size);
+  font-weight: var(--bs-btn-font-weight);
+  line-height: var(--bs-btn-line-height);
+  color: var(--bs-btn-color);
+  text-align: center;
+  text-decoration: none;
+  vertical-align: middle;
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+  border: var(--bs-btn-border-width) solid var(--bs-btn-border-color);
+  border-radius: var(--bs-btn-border-radius);
+  background-color: var(--bs-btn-bg);
+  transition:
+    color 0.15s ease-in-out,
+    background-color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out,
+    box-shadow 0.15s ease-in-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .btn {
+    transition: none;
+  }
+}
+.btn:hover {
+  color: var(--bs-btn-hover-color);
+  background-color: var(--bs-btn-hover-bg);
+  border-color: var(--bs-btn-hover-border-color);
+}
+.btn:focus-visible {
+  color: var(--bs-btn-hover-color);
+  background-color: var(--bs-btn-hover-bg);
+  border-color: var(--bs-btn-hover-border-color);
+  outline: 0;
+  box-shadow: var(--bs-btn-focus-box-shadow);
+}
+:not(.btn-check) + .btn:active,
+.btn:first-child:active,
+.btn.show {
+  color: var(--bs-btn-active-color);
+  background-color: var(--bs-btn-active-bg);
+  border-color: var(--bs-btn-active-border-color);
+}
+:not(.btn-check) + .btn:active:focus-visible,
+.btn:first-child:active:focus-visible,
+.btn.show:focus-visible {
+  box-shadow: var(--bs-btn-focus-box-shadow);
+}
+.btn:disabled,
+.btn.disabled {
+  color: var(--bs-btn-disabled-color);
+  pointer-events: none;
+  background-color: var(--bs-btn-disabled-bg);
+  border-color: var(--bs-btn-disabled-border-color);
+  opacity: var(--bs-btn-disabled-opacity);
+}
+.btn-primary {
+  --bs-btn-color: #fff;
+  --bs-btn-bg: teal;
+  --bs-btn-border-color: teal;
+  --bs-btn-hover-color: #fff;
+  --bs-btn-hover-bg: #006d6d;
+  --bs-btn-hover-border-color: #006666;
+  --bs-btn-focus-shadow-rgb: 38, 147, 147;
+  --bs-btn-active-color: #fff;
+  --bs-btn-active-bg: #006666;
+  --bs-btn-active-border-color: #006060;
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #fff;
+  --bs-btn-disabled-bg: teal;
+  --bs-btn-disabled-border-color: teal;
+}
+.btn-danger {
+  --bs-btn-color: #fff;
+  --bs-btn-bg: var(--bs-danger);
+  --bs-btn-border-color: var(--bs-danger);
+  --bs-btn-hover-color: #fff;
+  --bs-btn-hover-bg: var(--bs-danger-text-emphasis);
+  --bs-btn-hover-border-color: var(--bs-danger-text-emphasis);
+  --bs-btn-focus-shadow-rgb: var(--bs-danger-rgb);
+  --bs-btn-active-color: #fff;
+  --bs-btn-active-bg: var(--bs-danger);
+  --bs-btn-active-border-color: var(--bs-danger) --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  --bs-btn-disabled-color: #fff;
+  --bs-btn-disabled-bg: var(--bs-danger);
+  --bs-btn-disabled-border-color: var(--bs-danger);
+}
+.btn-sm {
+  --bs-btn-padding-y: 0.25rem;
+  --bs-btn-padding-x: 0.5rem;
+  --bs-btn-font-size: 0.875rem;
+  --bs-btn-border-radius: var(--bs-border-radius-sm);
+}
+.dropdown {
+  position: relative;
+}
+@keyframes progress-bar-stripes {
+  0% {
+    background-position-x: 1rem;
+  }
+}
+.progress {
+  --bs-progress-height: 1rem;
+  --bs-progress-font-size: 0.75rem;
+  --bs-progress-bg: var(--bs-secondary-bg);
+  --bs-progress-border-radius: var(--bs-border-radius);
+  --bs-progress-box-shadow: var(--bs-box-shadow-inset);
+  --bs-progress-bar-color: #fff;
+  --bs-progress-bar-bg: teal;
+  --bs-progress-bar-transition: width 0.6s ease;
+  display: flex;
+  height: var(--bs-progress-height);
+  overflow: hidden;
+  font-size: var(--bs-progress-font-size);
+  background-color: var(--bs-progress-bg);
+  border-radius: var(--bs-progress-border-radius);
+}
+@keyframes spinner-border {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@keyframes spinner-grow {
+  0% {
+    transform: scale(0);
+  }
+  50% {
+    opacity: 1;
+    transform: none;
+  }
+}
+.placeholder {
+  display: inline-block;
+  min-height: 1em;
+  vertical-align: middle;
+  cursor: wait;
+  background-color: currentcolor;
+  opacity: 0.5;
+}
+.placeholder.btn:before {
+  display: inline-block;
+  content: "";
+}
+@keyframes placeholder-glow {
+  50% {
+    opacity: 0.2;
+  }
+}
+@keyframes placeholder-wave {
+  to {
+    -webkit-mask-position: -200% 0%;
+    mask-position: -200% 0%;
+  }
+}
+.vr {
+  display: inline-block;
+  align-self: stretch;
+  width: var(--bs-border-width);
+  min-height: 1em;
+  background-color: currentcolor;
+  opacity: 0.25;
+}
+.mx-2 {
+  margin-right: 0.5rem !important;
+  margin-left: 0.5rem !important;
+}
+.my-4 {
+  margin-top: 1.5rem !important;
+  margin-bottom: 1.5rem !important;
+}
+.mb-3 {
+  margin-bottom: 1rem !important;
+}
+.text-center {
+  text-align: center !important;
+}
+.text-danger {
+  --bs-text-opacity: 1;
+  color: rgba(var(--bs-danger-rgb), var(--bs-text-opacity)) !important;
+}
+.text-light {
+  --bs-text-opacity: 1;
+  color: rgba(var(--bs-light-rgb), var(--bs-text-opacity)) !important;
+}
+.visible {
+  visibility: visible !important;
+}
+:root {
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 400;
+  margin: 0 auto;
+  color-scheme: light dark;
+  color: #ffffffde;
+  background-color: #1d2022;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-text-size-adjust: 100%;
+}
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  background-color: #1d2022;
+  color: #f8f9fa;
+}
+@media (prefers-color-scheme: light) {
+  :root {
+    color: #213547;
+    background-color: #fff;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import App from "./App.tsx";
 
-// import "bootstrap/dist/js/bootstrap.bundle.js";
+import App from "./App.tsx";
 import "./index.scss";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@
 import path from "path";
 import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react-swc'
-
+import pluginPurgeCss from "@mojojoejo/vite-plugin-purgecss"
 // @ts-ignore
 import pathsFromConfig from "./tsconfig.paths.json";
 
@@ -16,7 +16,8 @@ export default defineConfig(({ command, mode}) => {
   let openBrowser = mode === "development";
 
   return { 
-    plugins: [react()],
+    plugins: [react(), 
+      pluginPurgeCss()],
     resolve: {
       alias: resolveTSConfigPathAlias(),
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1292,6 +1292,13 @@
   resolved "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.4.tgz"
   integrity sha512-qprfWkn82Iw821mcKofJ5Pk9wgioHicxcQMxx+5zt5GSKoqdWvgG5AxVmpmUUjzTLPVSH5auBrhI93Deayn/DA==
 
+"@fullhuman/postcss-purgecss@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-5.0.0.tgz#70db9a537c73750fbcf745b49573db758daba1d8"
+  integrity sha512-onDS/b/2pMRzqSoj4qOs2tYFmOpaspjTAgvACIHMPiicu1ptajiBruTrjBzTKdxWdX0ldaBb7wj8nEaTLyFkJw==
+  dependencies:
+    purgecss "^5.0.0"
+
 "@humanwhocodes/config-array@^0.11.11":
   version "0.11.11"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz"
@@ -1310,6 +1317,18 @@
   version "1.2.1"
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -1432,6 +1451,13 @@
   dependencies:
     "@types/mdx" "^2.0.0"
     "@types/react" ">=16"
+
+"@mojojoejo/vite-plugin-purgecss@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@mojojoejo/vite-plugin-purgecss/-/vite-plugin-purgecss-1.1.0.tgz#3ef384249758df8e7b80e73328f24c5245c3489f"
+  integrity sha512-J9hgBEsvP5f1XvejZVynO1gVZn6ruin5dLjr3FSjtf7Z6f8A9VqOJr2pZVGzP6Nc9ih5HSTuw3cPAOg8DzgZTQ==
+  dependencies:
+    purgecss "^5.0.0"
 
 "@ndelangen/get-tarball@^3.0.7":
   version "3.0.9"
@@ -3900,11 +3926,6 @@ body-parser@1.20.1:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
-bootstrap@^5.3.2:
-  version "5.3.2"
-  resolved "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.2.tgz"
-  integrity sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==
-
 bplist-parser@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz"
@@ -4167,15 +4188,6 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
-cliui@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
-  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
-  dependencies:
-    string-width "^4.2.0"
-    strip-ansi "^6.0.1"
-    wrap-ansi "^7.0.0"
-
 clone-deep@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz"
@@ -4240,6 +4252,11 @@ commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
+commander@^9.0.0:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
+  integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -4343,6 +4360,11 @@ css.escape@^1.5.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz"
   integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
+
+cssesc@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 cssstyle@^3.0.0:
   version "3.0.0"
@@ -5322,6 +5344,17 @@ glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^8.0.3:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
@@ -5899,12 +5932,12 @@ istanbul-reports@^3.1.4, istanbul-reports@^3.1.5:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jackspeak@2.1.1, jackspeak@^2.3.5:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.1.1.tgz#2a42db4cfbb7e55433c28b6f75d8b796af9669cd"
-  integrity sha512-juf9stUEwUaILepraGOWIJTLwg48bUnBmRqd2ln2Os1sW987zeoj/hzhbvRB95oMuS2ZTpjULmdwHNX4rzZIZw==
+jackspeak@^2.1.1, jackspeak@^2.3.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-2.3.6.tgz#647ecc472238aee4b06ac0e461acc21a8c505ca8"
+  integrity sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==
   dependencies:
-    cliui "^8.0.1"
+    "@isaacs/cliui" "^8.0.2"
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
@@ -6933,7 +6966,15 @@ polished@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.17.8"
 
-postcss@^8.4.27:
+postcss-selector-parser@^6.0.7:
+  version "6.0.13"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz#d05d8d76b1e8e173257ef9d60b706a8e5e99bf1b"
+  integrity sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
+
+postcss@^8.4.27, postcss@^8.4.4:
   version "8.4.31"
   resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz"
   integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
@@ -7075,6 +7116,16 @@ puppeteer-core@^2.1.1:
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
     ws "^6.1.0"
+
+purgecss@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/purgecss/-/purgecss-5.0.0.tgz#08526ba3fef95e42c54503ca59d3f2ee8d6e5189"
+  integrity sha512-RAnuxrGuVyLLTr8uMbKaxDRGWMgK5CCYDfRyUNNcaz5P3kGgD2b7ymQGYEyo2ST7Tl/ScwFgf5l3slKMxHSbrw==
+  dependencies:
+    commander "^9.0.0"
+    glob "^8.0.3"
+    postcss "^8.4.4"
+    postcss-selector-parser "^6.0.7"
 
 qs@6.11.0:
   version "6.11.0"
@@ -7793,6 +7844,15 @@ string-argv@0.3.2:
   resolved "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
@@ -7802,7 +7862,7 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^5.0.0, string-width@^5.0.1:
+string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz"
   integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
@@ -7824,6 +7884,13 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -8521,6 +8588,15 @@ wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
You will now have to provide the css classes in defaultStyles field or the stylesSchema field of the input schema.

StylesSchema inside an input will override the default styles of the form

```tsx
  defaultStyles: {
    title: "text-center mb-3",
    form: "row",
    buttons: {
      wrapper: "text-center",
      submit: "btn btn-primary mx-2 btn-sm",
      clear: "btn btn-danger mx-2 btn-sm",
    },
    inputs: {
      fieldWrapper: "mb-3 row",
      inputWrapper: "col-sm-10",
      input: "form-control",
      label: "col-sm-2 col-form-label",
      placeHolder: "",
      helpText: "form-text",
    },
  },
```
Or

```tsx
      stylesSchema: {
        fieldWrapper: "mb-3 row",
        inputWrapper: "col-sm-10",
        input: "form-control",
        label: "col-sm-2 col-form-label",
        placeHolder: "",
        helpText: "form-text",
      },
```